### PR TITLE
Bump werkzeug

### DIFF
--- a/mediapipe/model_maker/requirements_lock.txt
+++ b/mediapipe/model_maker/requirements_lock.txt
@@ -327,7 +327,7 @@ urllib3==2.2.3
     #   requests
 webencodings==0.5.1
     # via bleach
-werkzeug==3.0.4
+werkzeug==3.0.6
     # via tensorboard
 wheel==0.44.0
     # via astunparse


### PR DESCRIPTION
Bumps the pip group with 1 update in the /mediapipe/model_maker directory: [werkzeug](https://github.com/pallets/werkzeug).


Updates `werkzeug` from 3.0.4 to 3.0.6
- [Release notes](https://github.com/pallets/werkzeug/releases)
- [Changelog](https://github.com/pallets/werkzeug/blob/main/CHANGES.rst)
- [Commits](https://github.com/pallets/werkzeug/compare/3.0.4...3.0.6)

---
updated-dependencies:
- dependency-name: werkzeug dependency-type: direct:production dependency-group: pip ...